### PR TITLE
Fix first day of the month issue

### DIFF
--- a/utils/FetchManager.js
+++ b/utils/FetchManager.js
@@ -107,9 +107,10 @@ class FetchManager {
 	// };
 
 	fetchCalendarDay = async (group, date) => {
+		const endQueryDate = moment(date, "YYYY-MM-DD").add(1,'day').format("YYYY-MM-DD");
 		const data = {
 			start: date,
-			end: date,
+			end: endQueryDate,
 			resType: '103',
 			calView: 'agendaDay',
 			'federationIds[]': group,


### PR DESCRIPTION
Fix #34 
This bug appeared because when requesting Celcat API with the same date as both start and end field, nothing would return when it's the first day of the month (for some mysterious reason).

This PR will hopefully fix this bug by always requesting the next day as the end date field from now on (as Celcat is already doing)