### PR TITLE
URGENT: Use new URL

### DIFF
--- a/utils/WebApiURL.js
+++ b/utils/WebApiURL.js
@@ -1,5 +1,5 @@
 export default {
-	DOMAIN: 'https://ukit.kbdev.io/Home/',
+	DOMAIN: 'https://ukit.kbdev.io/Calendar/Home/',
 	GROUPS: 'ReadResourceListItems',
 	CALENDARDATA: 'GetCalendarData',
 	SIDEBAR: 'GetSideBarEvent',


### PR DESCRIPTION
I don't know why, but the university changed the URL required to access the calendar.
The app shows no classes and throws an "undefined is not an object (evaluating 's.map')" error when opening the app.

Celcat isn't always reliable, I would suggest a cached schedule only be saved if it isn't empty, which would avoid Celcat errors from erasing the cache. Had this been how the cache worked before, many would not have noticed the errors today.